### PR TITLE
Making Adyen Payments compatible with Magento 2.4.8 version and PHP 8.1+

### DIFF
--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -173,7 +173,7 @@ class Index extends Action
     /**
      * @throws LocalizedException
      */
-    private function getOrder(string $incrementId = null): Order
+    private function getOrder(?string $incrementId = null): Order
     {
         if ($incrementId !== null) {
             $order = $this->orderFactory->create()->loadByIncrementId($incrementId);

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -78,11 +78,11 @@ class Config
     }
 
     /**
-     * @param $mode
-     * @param mixed $storeId
+     * @param string $mode
+     * @param int|string|null $storeId
      * @return string
      */
-    public function getApiKey($mode, $storeId = null): string
+    public function getApiKey(string $mode, int|string|null $storeId = null): string
     {
         $apiKey = $this->getConfigData('api_key_' . $mode, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId);
 
@@ -90,16 +90,16 @@ class Config
     }
 
     /**
-     * @param $mode
-     * @param $storeId
+     * @param string $mode
+     * @param int|string|null $storeId
      * @return string|null
      */
-    public function getClientKey($mode, $storeId = null): ?string
+    public function getClientKey(string $mode, int|string|null $storeId = null): ?string
     {
         return $this->getConfigData('client_key_' . $mode, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId);
     }
 
-    public function getIsPaymentMethodsActive($storeId = null): bool
+    public function getIsPaymentMethodsActive(int|string|null $storeId = null): bool
     {
         return $this->getConfigData(
             self::XML_PAYMENT_METHODS_ACTIVE,
@@ -109,10 +109,10 @@ class Config
     }
 
     /**
-     * @param int|null $storeId
+     * @param int|string|null $storeId
      * @return string|null
      */
-    public function getMerchantAccount($storeId = null): ?string
+    public function getMerchantAccount(int|string|null $storeId = null): ?string
     {
         return $this->getConfigData(
             self::XML_MERCHANT_ACCOUNT,
@@ -122,10 +122,10 @@ class Config
     }
 
     /**
-     * @param $storeId
+     * @param int|string|null $storeId
      * @return array|null
      */
-    public function getMotoMerchantAccounts($storeId = null): ?array
+    public function getMotoMerchantAccounts(int|string|null $storeId = null): ?array
     {
         $serializedData = $this->getConfigData(
             self::XML_MOTO_MERCHANT_ACCOUNTS,
@@ -137,10 +137,10 @@ class Config
     }
 
     /**
-     * @param $storeId
+     * @param int|string|null $storeId
      * @return bool|mixed
      */
-    public function isMotoPaymentMethodEnabled($storeId = null): bool
+    public function isMotoPaymentMethodEnabled(int|string|null $storeId = null): bool
     {
         return $this->getConfigData('active', Config::XML_ADYEN_MOTO, $storeId, true);
     }
@@ -149,11 +149,11 @@ class Config
      * Returns the properties of a MOTO merchant account in an array (API Key, Client Key, Demo Mode)
      *
      * @param string $motoMerchantAccount
-     * @param $storeId
+     * @param int|string|null $storeId
      * @return array
      * @throws AdyenException
      */
-    public function getMotoMerchantAccountProperties(string $motoMerchantAccount, $storeId = null) : array
+    public function getMotoMerchantAccountProperties(string $motoMerchantAccount, int|string|null $storeId = null) : array
     {
         $motoMerchantAccounts = $this->getMotoMerchantAccounts($storeId);
 
@@ -165,10 +165,10 @@ class Config
     }
 
     /**
-     * @param int|null $storeId
+     * @param int|string|null $storeId
      * @return string|null
      */
-    public function getNotificationsUsername($storeId = null): ?string
+    public function getNotificationsUsername(int|string|null $storeId = null): ?string
     {
         return $this->getConfigData(
             self::XML_NOTIFICATIONS_USERNAME,
@@ -178,10 +178,10 @@ class Config
     }
 
     /**
-     * @param int|null $storeId
+     * @param int|string|null $storeId
      * @return string|null
      */
-    public function getNotificationsPassword($storeId = null): ?string
+    public function getNotificationsPassword(int|string|null $storeId = null): ?string
     {
         $key = $this->getConfigData(
             self::XML_NOTIFICATIONS_PASSWORD,
@@ -196,10 +196,10 @@ class Config
     }
 
     /**
-     * @param mixed $storeId
+     * @param int|string|null $storeId
      * @return string|null
      */
-    public function getWebhookUrl($storeId = null): ?string
+    public function getWebhookUrl(int|string|null $storeId = null): ?string
     {
         return $this->getConfigData(
             self::XML_WEBHOOK_URL,
@@ -208,7 +208,7 @@ class Config
         );
     }
 
-    public function getWebhookId($storeId = null): ?string
+    public function getWebhookId(int|string|null $storeId = null): ?string
     {
         return $this->getConfigData('webhook_id', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId);
     }
@@ -216,10 +216,10 @@ class Config
     /**
      * Retrieve flag for notifications_can_cancel
      *
-     * @param mixed $storeId
+     * @param int|null $storeId
      * @return bool
      */
-    public function getNotificationsCanCancel($storeId = null): bool
+    public function getNotificationsCanCancel(int|string|null $storeId = null): bool
     {
         return (bool)$this->getConfigData(
             self::XML_NOTIFICATIONS_CAN_CANCEL_FIELD,
@@ -232,10 +232,10 @@ class Config
     /**
      * Retrieve key for notifications_hmac_key
      *
-     * @param mixed $storeId
+     * @param int|string|null $storeId
      * @return string|null
      */
-    public function getNotificationsHmacKey($storeId = null): ?string
+    public function getNotificationsHmacKey(int|string|null $storeId = null): ?string
     {
         if ($this->isDemoMode($storeId)) {
             $key = $this->getConfigData(
@@ -263,10 +263,10 @@ class Config
     /**
      * Retrieve flag for notifications_ip_check
      *
-     * @param int $storeId
+     * @param int|string|null $storeId
      * @return bool
      */
-    public function getNotificationsIpCheck(int $storeId = null): bool
+    public function getNotificationsIpCheck(int|string|null $storeId = null): bool
     {
         return (bool) $this->getConfigData(
             self::XML_NOTIFICATIONS_IP_CHECK,
@@ -276,17 +276,17 @@ class Config
         );
     }
 
-    public function isDemoMode($storeId = null): bool
+    public function isDemoMode(int|string|null $storeId = null): bool
     {
         return $this->getConfigData('demo_mode', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
     }
 
     /**
-     * @param $storeId
+     * @param int|string|null $storeId
      * @return bool|mixed
      * @deprecated
      */
-    public function isAlternativePaymentMethodsEnabled($storeId = null): bool
+    public function isAlternativePaymentMethodsEnabled(int|string|null $storeId = null): bool
     {
         return $this->getConfigData('active', Config::XML_ADYEN_HPP, $storeId, true);
     }
@@ -294,10 +294,10 @@ class Config
     /**
      * Retrieve charged currency selection (base or display)
      *
-     * @param null|int|string $storeId
+     * @param int|string|null $storeId
      * @return mixed
      */
-    public function getChargedCurrency($storeId = null)
+    public function getChargedCurrency(int|string|null $storeId = null)
     {
         return $this->getConfigData(self::XML_CHARGED_CURRENCY, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId);
     }
@@ -305,10 +305,10 @@ class Config
     /**
      * Retrieve has_holder_name config
      *
-     * @param null|int|string $storeId
+     * @param int|string|null $storeId
      * @return mixed
      */
-    public function getHasHolderName($storeId = null)
+    public function getHasHolderName(int|string|null $storeId = null)
     {
         return $this->getConfigData(self::XML_HAS_HOLDER_NAME, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
     }
@@ -319,7 +319,7 @@ class Config
      * @param null|int|string $storeId
      * @return mixed
      */
-    public function getHouseNumberStreetLine($storeId = null)
+    public function getHouseNumberStreetLine(int|string|null $storeId = null)
     {
         return $this->getConfigData(self::XML_HOUSE_NUMBER_STREET_LINE, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId);
     }
@@ -330,7 +330,7 @@ class Config
      * @param null|int|string $storeId
      * @return mixed
      */
-    public function getHolderNameRequired($storeId = null)
+    public function getHolderNameRequired(int|string|null $storeId = null)
     {
         return $this->getConfigData(self::XML_HOLDER_NAME_REQUIRED, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
     }
@@ -464,7 +464,7 @@ class Config
         return $this->getConfigData('adyen_support_email_address', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId);
     }
 
-    public function getAdyenPosCloudConfigData(string $field, int $storeId = null, bool $flag = false)
+    public function getAdyenPosCloudConfigData(string $field, int|string|null $storeId = null, bool $flag = false)
     {
         return $this->getConfigData($field, self::XML_ADYEN_POS_CLOUD, $storeId, $flag);
     }
@@ -474,7 +474,7 @@ class Config
         return $this->getAdyenPosCloudConfigData(self::XML_PAYMENT_ACTION, $storeId);
     }
 
-    public function useQueueProcessor($storeId = null): bool
+    public function useQueueProcessor(int|string|null $storeId = null): bool
     {
         return $this->getConfigData(
             self::XML_WEBHOOK_NOTIFICATION_PROCESSOR,
@@ -492,12 +492,12 @@ class Config
         );
     }
 
-    public function getAdyenAbstractConfigData(string $field, int $storeId = null): mixed
+    public function getAdyenAbstractConfigData(string $field, int|string|null $storeId = null): mixed
     {
         return $this->getConfigData($field, 'adyen_abstract', $storeId);
     }
 
-    public function getLiveEndpointPrefix(int $storeId = null): ?string
+    public function getLiveEndpointPrefix(int|string|null $storeId = null): ?string
     {
         $prefix = $this->getAdyenAbstractConfigData('live_endpoint_url_prefix', $storeId);
 
@@ -508,37 +508,37 @@ class Config
         return trim($prefix);
     }
 
-    public function getAdyenAbstractConfigDataFlag($field, $storeId = null): mixed
+    public function getAdyenAbstractConfigDataFlag(string $field, int|string|null $storeId = null): mixed
     {
         return $this->getConfigData($field, 'adyen_abstract', $storeId, true);
     }
 
-    public function getAdyenCcConfigData($field, $storeId = null): mixed
+    public function getAdyenCcConfigData(string $field, int|string|null $storeId = null): mixed
     {
         return $this->getConfigData($field, 'adyen_cc', $storeId);
     }
 
-    public function getAdyenHppConfigData($field, $storeId = null): mixed
+    public function getAdyenHppConfigData(string $field, int|string|null $storeId = null): mixed
     {
         return $this->getConfigData($field, 'adyen_hpp', $storeId);
     }
 
-    public function getAdyenHppVaultConfigDataFlag($field, $storeId = null): mixed
+    public function getAdyenHppVaultConfigDataFlag(string $field, int|string|null $storeId = null): mixed
     {
         return $this->getConfigData($field, 'adyen_hpp_vault', $storeId, true);
     }
 
-    public function isHppVaultEnabled($storeId = null): mixed
+    public function isHppVaultEnabled(int|string|null $storeId = null): mixed
     {
         return $this->getAdyenHppVaultConfigDataFlag('active', $storeId);
     }
 
-    public function getAdyenOneclickConfigData($field, int $storeId = null): mixed
+    public function getAdyenOneclickConfigData(string $field, int|string|null $storeId = null): mixed
     {
         return $this->getConfigData($field, 'adyen_oneclick', $storeId);
     }
 
-    public function getAdyenOneclickConfigDataFlag($field, int $storeId = null): bool
+    public function getAdyenOneclickConfigDataFlag(string $field, int|string|null $storeId = null): bool
     {
         return $this->getConfigData($field, 'adyen_oneclick', $storeId, true);
     }
@@ -548,12 +548,12 @@ class Config
         return !$this->getAdyenOneclickConfigDataFlag('share_billing_agreement', $storeId);
     }
 
-    public function getAdyenBoletoConfigData(string $field, int $storeId = null): mixed
+    public function getAdyenBoletoConfigData(string $field, int|string|null $storeId = null): mixed
     {
         return $this->getConfigData($field, 'adyen_boleto', $storeId);
     }
 
-    public function getCheckoutFrontendRegion(int $storeId = null): ?string
+    public function getCheckoutFrontendRegion(int|string|null $storeId = null): ?string
     {
         $checkoutFrontendRegion = $this->getAdyenAbstractConfigData('checkout_frontend_region', $storeId);
 
@@ -564,12 +564,12 @@ class Config
         return trim($checkoutFrontendRegion);
     }
 
-    public function getRatePayId(int $storeId = null)
+    public function getRatePayId(int|string|null $storeId = null)
     {
         return $this->getConfigData("ratepay_id", self::XML_ADYEN_RATEPAY, $storeId);
     }
 
-    public function getAllowMultistoreTokens(int $storeId = null): ?bool
+    public function getAllowMultistoreTokens(int|string|null $storeId = null): ?bool
     {
         return $this->getConfigData(
             self::XML_ALLOW_MULTISTORE_TOKENS,
@@ -582,10 +582,10 @@ class Config
     /**
      * Returns the preferred ThreeDS authentication type for card and card vault payments.
      *
-     * @param int|null $storeId
+     * @param int|string|null $storeId
      * @return string
      */
-    public function getThreeDSFlow(int $storeId = null): string
+    public function getThreeDSFlow(int|string|null $storeId = null): string
     {
         return $this->getConfigData(
             self::XML_THREEDS_FLOW,
@@ -629,7 +629,7 @@ class Config
         );
     }
 
-    public function getIsCvcRequiredForRecurringCardPayments(int $storeId = null): bool
+    public function getIsCvcRequiredForRecurringCardPayments(int|string|null $storeId = null): bool
     {
          return (bool) $this->getConfigData(
             'require_cvc',
@@ -639,7 +639,7 @@ class Config
         );
     }
 
-    public function getConfigData(string $field, string $xmlPrefix, ?int $storeId, bool $flag = false): mixed
+    public function getConfigData(string $field, string $xmlPrefix, int|string|null $storeId, bool $flag = false): mixed
     {
         $path = implode("/", [self::XML_PAYMENT_PREFIX, $xmlPrefix, $field]);
 

--- a/Helper/ConnectedTerminals.php
+++ b/Helper/ConnectedTerminals.php
@@ -31,7 +31,7 @@ class ConnectedTerminals
         $this->adyenLogger = $adyenLogger;
     }
 
-    public function getConnectedTerminals(int $storeId = null): array
+    public function getConnectedTerminals(?int $storeId = null): array
     {
         if (!isset($storeId)) {
             $storeId = $this->session->getQuote()->getStoreId();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1442,7 +1442,7 @@ class Data extends AbstractHelper
      * @throws NoSuchEntityException
      * @deprecared use `initializePaymentsApi`, or `initializeModificationsApi` based on your case
      */
-    public function createAdyenCheckoutService(Client $client = null): Checkout
+    public function createAdyenCheckoutService(?Client $client = null): Checkout
     {
         if (!$client) {
             $client = $this->initializeAdyenClient();

--- a/Logger/AdyenLogger.php
+++ b/Logger/AdyenLogger.php
@@ -16,15 +16,10 @@ use Magento\Framework\Phrase;
 use Magento\Sales\Model\Order as MagentoOrder;
 use Magento\Store\Model\StoreManagerInterface;
 use Monolog\Logger;
+use Monolog\Level;
 
 class AdyenLogger extends Logger
 {
-    /**
-     * Detailed debug information
-     */
-    const ADYEN_DEBUG = 101;
-    const ADYEN_NOTIFICATION = 201;
-    const ADYEN_RESULT = 202;
     /**
      * Logging levels from syslog protocol defined in RFC 5424
      * Overrule the default to add Adyen specific loggers to log into seperate files
@@ -33,10 +28,7 @@ class AdyenLogger extends Logger
      */
     protected static $levels = [
         100 => 'DEBUG',
-        101 => 'ADYEN_DEBUG',
         200 => 'INFO',
-        201 => 'ADYEN_NOTIFICATION',
-        202 => 'ADYEN_RESULT',
         250 => 'NOTICE',
         300 => 'WARNING',
         400 => 'ERROR',
@@ -73,14 +65,14 @@ class AdyenLogger extends Logger
      */
     public function addAdyenNotification($message, array $context = [])
     {
-        return $this->addRecord(static::ADYEN_NOTIFICATION, $message, $context);
+        return $this->addRecord(Level::Notice, $message, $context);
     }
 
     public function addAdyenDebug($message, array $context = [])
     {
         $storeId = $this->storeManager->getStore()->getId();
         if ($this->config->debugLogsEnabled($storeId)) {
-            return $this->addRecord(static::ADYEN_DEBUG, $message, $context);
+            return $this->addRecord(Level::Debug, $message, $context);
         }
     }
 
@@ -91,7 +83,7 @@ class AdyenLogger extends Logger
 
     public function addAdyenResult($message, array $context = [])
     {
-        return $this->addRecord(static::ADYEN_RESULT, $message, $context);
+        return $this->addRecord(Level::Debug, $message, $context);
     }
 
     /**

--- a/Logger/Handler/AdyenBase.php
+++ b/Logger/Handler/AdyenBase.php
@@ -14,6 +14,7 @@ namespace Adyen\Payment\Logger\Handler;
 use Magento\Framework\Logger\Handler\Base;
 use Monolog\Formatter\LineFormatter;
 use Magento\Framework\Filesystem\DriverInterface;
+use Monolog\LogRecord;
 
 class AdyenBase extends Base
 {
@@ -43,7 +44,7 @@ class AdyenBase extends Base
      *
      * {@inheritdoc}
      */
-    public function isHandling(array $record): bool
+    public function isHandling(LogRecord $record): bool
     {
         return $record['level'] == $this->level;
     }

--- a/Logger/Handler/AdyenDebug.php
+++ b/Logger/Handler/AdyenDebug.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Logger\Handler;
 
 use Adyen\Payment\Logger\AdyenLogger;
 use Monolog\Logger;
+use Monolog\Level;
 
 class AdyenDebug extends AdyenBase
 {
@@ -24,7 +25,7 @@ class AdyenDebug extends AdyenBase
     /**
      * @var int
      */
-    protected $loggerType = AdyenLogger::ADYEN_DEBUG;
+    protected $loggerType = Level::Debug;
 
-    protected $level = AdyenLogger::ADYEN_DEBUG;
+    protected Level $level = Level::Debug;
 }

--- a/Logger/Handler/AdyenError.php
+++ b/Logger/Handler/AdyenError.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Logger\Handler;
 
 use Adyen\Payment\Logger\AdyenLogger;
 use Monolog\Logger;
+use Monolog\Level;
 
 class AdyenError extends AdyenBase
 {
@@ -29,5 +30,5 @@ class AdyenError extends AdyenBase
     /**
      * @var
      */
-    protected $level = AdyenLogger::ERROR;
+    protected Level $level = Level::Error;
 }

--- a/Logger/Handler/AdyenInfo.php
+++ b/Logger/Handler/AdyenInfo.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Logger\Handler;
 
 use Adyen\Payment\Logger\AdyenLogger;
 use Monolog\Logger;
+use Monolog\Level;
 
 class AdyenInfo extends AdyenBase
 {
@@ -26,5 +27,5 @@ class AdyenInfo extends AdyenBase
      */
     protected $loggerType = AdyenLogger::INFO;
 
-    protected $level = AdyenLogger::INFO;
+    protected Level $level = Level::Info;
 }

--- a/Logger/Handler/AdyenNotification.php
+++ b/Logger/Handler/AdyenNotification.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Logger\Handler;
 
 use Monolog\Logger;
 use Adyen\Payment\Logger\AdyenLogger;
+use Monolog\Level;
 
 class AdyenNotification extends AdyenBase
 {
@@ -24,7 +25,7 @@ class AdyenNotification extends AdyenBase
     /**
      * @var int
      */
-    protected $loggerType = AdyenLogger::ADYEN_NOTIFICATION;
+    protected $loggerType = Level::Notice;
 
-    protected $level = AdyenLogger::ADYEN_NOTIFICATION;
+    protected Level $level = Level::Notice;
 }

--- a/Logger/Handler/AdyenResult.php
+++ b/Logger/Handler/AdyenResult.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Logger\Handler;
 
 use Monolog\Logger;
 use Adyen\Payment\Logger\AdyenLogger;
+use Monolog\Level;
 
 class AdyenResult extends AdyenBase
 {
@@ -24,7 +25,7 @@ class AdyenResult extends AdyenBase
     /**
      * @var int
      */
-    protected $loggerType = AdyenLogger::ADYEN_RESULT;
+    protected $loggerType = Level::Debug;
 
-    protected $level = AdyenLogger::ADYEN_RESULT;
+    protected Level $level = Level::Debug;
 }

--- a/Logger/Handler/AdyenWarning.php
+++ b/Logger/Handler/AdyenWarning.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Logger\Handler;
 
 use Adyen\Payment\Logger\AdyenLogger;
+use Monolog\Level;
 
 class AdyenWarning extends AdyenBase
 {
@@ -25,5 +26,5 @@ class AdyenWarning extends AdyenBase
      */
     protected $loggerType = AdyenLogger::WARNING;
 
-    protected $level = AdyenLogger::WARNING;
+    protected Level $level = Level::Warning;
 }

--- a/Model/Config/Backend/AutoConfiguration.php
+++ b/Model/Config/Backend/AutoConfiguration.php
@@ -61,8 +61,8 @@ class AutoConfiguration extends Value
         ManagementHelper $managementApiHelper,
         UrlInterface $url,
         BaseUrlHelper $baseUrlHelper,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);

--- a/Model/Config/Backend/DonationAmounts.php
+++ b/Model/Config/Backend/DonationAmounts.php
@@ -44,8 +44,8 @@ class DonationAmounts extends Value
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
         StoreManagerInterface $storeManager,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->storeManager = $storeManager;

--- a/Model/Config/Backend/Installments.php
+++ b/Model/Config/Backend/Installments.php
@@ -40,8 +40,8 @@ class Installments extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Framework\Math\Random $mathRandom,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->mathRandom = $mathRandom;

--- a/Model/Config/Backend/InstallmentsPosCloud.php
+++ b/Model/Config/Backend/InstallmentsPosCloud.php
@@ -41,8 +41,8 @@ class InstallmentsPosCloud extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Framework\Math\Random $mathRandom,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->mathRandom = $mathRandom;

--- a/Model/Config/Backend/Moto.php
+++ b/Model/Config/Backend/Moto.php
@@ -54,8 +54,8 @@ class Moto extends \Magento\Framework\App\Config\Value
         \Magento\Framework\Math\Random $mathRandom,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
         \Magento\Framework\Encryption\EncryptorInterface $encryptor,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->encryptor = $encryptor;

--- a/Model/Config/Backend/OrderStatus.php
+++ b/Model/Config/Backend/OrderStatus.php
@@ -31,20 +31,20 @@ class OrderStatus extends \Magento\Framework\App\Config\Value
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
      * @param \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList
-     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
-     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
      * @param WriterInterface $configWriter
      * @param array $data
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         WriterInterface $configWriter,
         PaymentMethods $paymentMethodsHelper,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->configWriter = $configWriter;

--- a/Model/Config/Backend/PaymentMethodsStatus.php
+++ b/Model/Config/Backend/PaymentMethodsStatus.php
@@ -30,8 +30,8 @@ class PaymentMethodsStatus extends Value
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
         PaymentMethods $paymentMethodsHelper,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->paymentMethodsHelper = $paymentMethodsHelper;

--- a/Model/Config/Backend/ProcessedWebhookRemoval.php
+++ b/Model/Config/Backend/ProcessedWebhookRemoval.php
@@ -32,8 +32,8 @@ class ProcessedWebhookRemoval extends Value
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
         private readonly ManagerInterface $messageManager,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);

--- a/Model/Config/Backend/Tokenization.php
+++ b/Model/Config/Backend/Tokenization.php
@@ -47,8 +47,8 @@ class Tokenization extends Value
         SerializerInterface $serializer,
         PaymentMethods $paymentMethodsHelper,
         Data $dataHelper,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->mathRandom = $mathRandom;

--- a/Model/Config/Backend/WebhookCredentials.php
+++ b/Model/Config/Backend/WebhookCredentials.php
@@ -61,8 +61,8 @@ class WebhookCredentials extends Value
         ManagementHelper $managementApiHelper,
         Config $configHelper,
         UrlInterface $url,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->managementApiHelper = $managementApiHelper;

--- a/Model/Creditmemo.php
+++ b/Model/Creditmemo.php
@@ -25,8 +25,8 @@ class Creditmemo extends AbstractModel implements CreditMemoInterface
     public function __construct(
         Context $context,
         Registry $registry,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/Model/Invoice.php
+++ b/Model/Invoice.php
@@ -25,8 +25,8 @@ class Invoice extends AbstractModel implements InvoiceInterface
     public function __construct(
         Context $context,
         Registry $registry,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/Model/Method/PaymentMethodVault.php
+++ b/Model/Method/PaymentMethodVault.php
@@ -37,7 +37,7 @@ class PaymentMethodVault extends Vault
         PaymentTokenManagementInterface $tokenManagement,
         OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory,
         $code,
-        Json $jsonSerializer = null
+        ?Json $jsonSerializer = null
     ) {
         parent::__construct(
             $config,

--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -54,8 +54,8 @@ class Notification extends AbstractModel implements NotificationInterface
     public function __construct(
         Context $context,
         Registry $registry,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/Model/Order/Payment.php
+++ b/Model/Order/Payment.php
@@ -34,8 +34,8 @@ class Payment extends AbstractModel implements OrderPaymentInterface
         Registry $registry,
         PricingData $pricingData,
         MagentoPaymentRepository $magentoPaymentRepository,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->magentoPaymentRepository = $magentoPaymentRepository;

--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -40,12 +40,12 @@ class OrderRepository extends SalesOrderRepository
         SortOrderBuilder $sortOrderBuilder,
         Metadata $metadata,
         SearchResultFactory $searchResultFactory,
-        CollectionProcessorInterface $collectionProcessor = null,
-        OrderExtensionFactory $orderExtensionFactory = null,
-        OrderTaxManagementInterface $orderTaxManagement = null,
-        PaymentAdditionalInfoInterfaceFactory $paymentAdditionalInfoFactory = null,
-        JsonSerializer $serializer = null,
-        JoinProcessorInterface $extensionAttributesJoinProcessor = null
+        ?CollectionProcessorInterface $collectionProcessor = null,
+        ?OrderExtensionFactory $orderExtensionFactory = null,
+        ?OrderTaxManagementInterface $orderTaxManagement = null,
+        ?PaymentAdditionalInfoInterfaceFactory $paymentAdditionalInfoFactory = null,
+        ?JsonSerializer $serializer = null,
+        ?JoinProcessorInterface $extensionAttributesJoinProcessor = null
     ) {
         parent::__construct(
             $metadata,

--- a/Model/TransportBuilder.php
+++ b/Model/TransportBuilder.php
@@ -147,11 +147,11 @@ class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
         FactoryInterface $templateFactory,
         SenderResolverInterface $senderResolver,
         ObjectManagerInterface $objectManager,
-        TransportInterfaceFactory $mailTransportFactory,
-        EmailMessageInterfaceFactory $emailMessageInterfaceFactory = null,
-        MimeMessageInterfaceFactory $mimeMessageInterfaceFactory = null,
-        MimePartInterfaceFactory $mimePartInterfaceFactory = null,
-        AddressConverter $addressConverter = null
+        ?TransportInterfaceFactory $mailTransportFactory,
+        ?EmailMessageInterfaceFactory $emailMessageInterfaceFactory = null,
+        ?MimeMessageInterfaceFactory $mimeMessageInterfaceFactory = null,
+        ?MimePartInterfaceFactory $mimePartInterfaceFactory = null,
+        ?AddressConverter $addressConverter = null
     ) {
         $this->templateFactory = $templateFactory;
         $this->objectManager = $objectManager;

--- a/Test/Unit/Gateway/Http/Client/TransactionCaptureTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionCaptureTest.php
@@ -53,7 +53,7 @@ class TransactionCaptureTest extends AbstractAdyenTestCase
         ]);
     }
 
-    private function configureAdyenMocks(array $response = null, \Exception $exception = null): void
+    private function configureAdyenMocks(?array $response = null, ?\Exception $exception = null): void
     {
         $adyenClient = $this->createMock(Client::class);
         $checkoutModificationsService = $this->createMock(Checkout\ModificationsApi::class);

--- a/Test/Unit/Helper/ManagementHelperTest.php
+++ b/Test/Unit/Helper/ManagementHelperTest.php
@@ -564,12 +564,12 @@ class ManagementHelperTest extends AbstractAdyenTestCase
      * @return ManagementHelper
      */
     private function createManagementHelper(
-        StoreManager $storeManager = null,
-        EncryptorInterface $encryptor = null,
-        Data $dataHelper = null,
-        Config $configHelper = null,
-        AdyenLogger $adyenLogger = null,
-        ManagerInterface $messageManager = null
+        ?StoreManager $storeManager = null,
+        ?EncryptorInterface $encryptor = null,
+        ?Data $dataHelper = null,
+        ?Config $configHelper = null,
+        ?AdyenLogger $adyenLogger = null,
+        ?ManagerInterface $messageManager = null
     ): ManagementHelper {
 
         if (is_null($storeManager)) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The changes in this pull request primarily focus on updating type hints in various PHP files to improve compatibility with PHP 8.1+ and Magento 2.4.8. Additionally, the logging classes have been refactored to utilize the standard Monolog Level enum, which is a good practice. The changes appear to be well-implemented and directly address the stated objective of the pull request.
Summary of Findings

- PHP 8.1+ Type Hinting: The pull request correctly introduces nullable type hints (?) and union types (int|string|null) to function parameters and properties where appropriate, aligning the code with stricter type checking requirements in PHP 8.1+.
- Monolog Level Enum Usage: The custom log levels in AdyenLogger have been replaced with the standard Monolog\Level enum, and the corresponding handlers have been updated. This improves consistency and adherence to the Monolog library's practices.
- Severity Assessment: Based on the review criteria and the requested severity levels (medium, high, critical), no issues falling within these categories were identified in the code changes.


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
